### PR TITLE
[OPT] change double into float

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Introduction à la programmation en langage C
 
 Nous allons aborder dans ce cours les notions fondamentales de la programmation informatique et de l'algorithmie avec le langage de programmation C.
 
-Nous disposons de 11 séances de 3 heures de cours en présentiel.
 
 Celles-ci auront la forme de travaux dirigés composés d'activités à réaliser en autonomie.
 


### PR DESCRIPTION
Dans le cadre de cet exercice, typer les variables en double est une mauvaise utilisation de la mémoire. En effet, les ``double`` étant encodé sur 64bit ont un précision d'environ 15 à 17 chiffres après la virgule ce qui est inutile étant donné que (par défaut et comme montré dans l'exemple) ``printf`` n'a une précision que de 6 chiffres après la virgule. Cette précision est apportée par un simple ``float`` (encodé sur 32bit et donc ayant une précision d'environ 7 à 9 chiffres après la virgule).